### PR TITLE
 ods-dsseen configurable and logging timestamps

### DIFF
--- a/ods-dsseen
+++ b/ods-dsseen
@@ -36,6 +36,11 @@ nosql() {
 	egrep -v '^MySQL database' 
 }
 
+# echo string with datetime prepended
+echo_time() {
+  echo `date --iso-8601=seconds` $1
+}
+
 
 # get OpenDNSSEC version
 ods_version() {
@@ -77,7 +82,7 @@ fi
 case $(ods_version) in
 	1.3*) keytagcol=9 ;;
 	1.4*) keytagcol=12 ;;
-	*) echo "Unknown OpenDNSSEC version, bailing out!"; exit 1 ;;
+	*) echo_time "Unknown OpenDNSSEC version, bailing out!"; exit 1 ;;
 esac
 
 dns=$(mktemp)
@@ -87,7 +92,7 @@ for zone in $zones; do
 	# dig: 39269 8 2 9EC50E7BBCC4095355A776D6183773197C05F320FDDE87E513022DB9 6A1E2F48
 	$DIG +adflag +aaonly  +short -t DS $zone $server | cut -d ' ' -f 1| sort > $dns
 	if [ ! -s "$dns" ]; then # $dns should never be empty
-		echo "warning: no key(s) for $zone found in DNS at all"
+		echo_time "warning: no key(s) for $zone found in DNS at all"
 	fi
 
 	# Keytags of dnskeys that are 'waiting for ds-seen'
@@ -101,13 +106,13 @@ for zone in $zones; do
 	if [ "$activate" == "yes" ]; then
 		if [ "$force" == "yes" ]; then
 			available=$(cat $ods)
-			echo "warning: forced activation of key(s) $available:$zone"
+			echo_time "warning: forced activation of key(s) $available:$zone"
 		fi
 		for keytag in $available; do
 			output=$($KSMUTIL key ds-seen --zone $zone --keytag $keytag 2>&1 | nosql)
 			if [ "$quiet" == "no" ]; then
-				echo "$output"
-				echo "Key $keytag:$zone activated."
+				echo_time "$output"
+				echo_time "Key $keytag:$zone activated."
 			fi
 		done
 	fi
@@ -115,12 +120,12 @@ for zone in $zones; do
 	# logging
 	if [ "$quiet" == "no" ]; then
 		if [ -n "$unavailable" ]; then
-			echo "The key(s) with tag $unavailable:$zone are not present in DNS."
+			echo_time "The key(s) with tag $unavailable:$zone are not present in DNS."
 		else
 			if [ -n "$available" ]; then
-				echo "All keys for $zone are present in DNS."
+				echo_time "All keys for $zone are present in DNS."
 			else
-				echo "No unactivated keys for $zone found in DNS."
+				echo_time "No unactivated keys for $zone found in DNS."
 			fi
 		fi
 	fi

--- a/ods-dsseen
+++ b/ods-dsseen
@@ -16,6 +16,10 @@
 # - match on CKAID instead of keytag
 #
 
+# Config
+KSMUTIL="ods-ksmutil"
+DIG="dig"
+
 usage() {
 	echo "usage: $0 [--activate|--force|--quiet|--help] <zone|...>" 
 	echo "Check if all DS-records are available through DNS and (optionally) activate the key."
@@ -35,7 +39,7 @@ nosql() {
 
 # get OpenDNSSEC version
 ods_version() {
-	ods-ksmutil --version | cut -d ' ' -f 3
+	$KSMUTIL --version | cut -d ' ' -f 3
 }
 
 # TODO
@@ -59,8 +63,8 @@ do
 		--activate)    activate="yes" ;;
 		--force)       activate="yes" ; force="yes";;
 		--quiet)       quiet="yes" ;;
-		--all)         zones=$(echo " "; ods-ksmutil key list 2>&1 | nosql | egrep -v 'Keys:|Zone:' | awk '/waiting for ds-seen/ {print $1}' | sort -u);;
-		--really-all)  zones=$(echo " "; ods-ksmutil key list 2>&1 | nosql | egrep -v 'Keys:|Zone:' | awk '{print $1}' | sort -u);;
+		--all)         zones=$(echo " "; $KSMUTIL key list 2>&1 | nosql | egrep -v 'Keys:|Zone:' | awk '/waiting for ds-seen/ {print $1}' | sort -u);;
+		--really-all)  zones=$(echo " "; $KSMUTIL key list 2>&1 | nosql | egrep -v 'Keys:|Zone:' | awk '{print $1}' | sort -u);;
 		*)             zones="$zones $option" ;;
 	esac
 done
@@ -81,14 +85,14 @@ ods=$(mktemp)
 for zone in $zones; do
 	# Keytags that can be retrieved from DNS
 	# dig: 39269 8 2 9EC50E7BBCC4095355A776D6183773197C05F320FDDE87E513022DB9 6A1E2F48
-	dig +adflag +aaonly  +short -t DS $zone $server | cut -d ' ' -f 1| sort > $dns
+	$DIG +adflag +aaonly  +short -t DS $zone $server | cut -d ' ' -f 1| sort > $dns
 	if [ ! -s "$dns" ]; then # $dns should never be empty
 		echo "warning: no key(s) for $zone found in DNS at all"
 	fi
 
 	# Keytags of dnskeys that are 'waiting for ds-seen'
 	# ods-ksmutil: mijnuvt.nl  KSK ready  waiting for ds-seen    d3fe6d5bc1ea73bed16d449d42dcf5e7  LocalHSM  39269
-	ods-ksmutil key list -v  --zone $zone 2>&1 |nosql | awk -v col=$keytagcol '/waiting for ds-seen/ {print $col}' |sort -u > $ods
+	$KSMUTIL key list -v  --zone $zone 2>&1 |nosql | awk -v col=$keytagcol '/waiting for ds-seen/ {print $col}' |sort -u > $ods
 
 	available=$(  comm -12 $ods $dns)
 	unavailable=$(comm -23 $ods $dns)
@@ -100,7 +104,7 @@ for zone in $zones; do
 			echo "warning: forced activation of key(s) $available:$zone"
 		fi
 		for keytag in $available; do
-			output=$(ods-ksmutil key ds-seen --zone $zone --keytag $keytag 2>&1 | nosql)
+			output=$($KSMUTIL key ds-seen --zone $zone --keytag $keytag 2>&1 | nosql)
 			if [ "$quiet" == "no" ]; then
 				echo "$output"
 				echo "Key $keytag:$zone activated."

--- a/ods-dsseen
+++ b/ods-dsseen
@@ -17,8 +17,16 @@
 #
 
 # Config
+# KSMUTIL: if not in path, specify full path to ods-ksmutil
 KSMUTIL="ods-ksmutil"
+# DIG: if not in path, specify full path to dig
 DIG="dig"
+
+# TODO
+# In fact we should _not_ use a /caching/-resolver
+# format: @HOSTNAME or empty to use the default servers
+# server="@dns1.uvt.nl"
+server="@ns0.tilburg1.surf.net"
 
 usage() {
 	echo "usage: $0 [--activate|--force|--quiet|--help] <zone|...>" 
@@ -46,12 +54,6 @@ echo_time() {
 ods_version() {
 	$KSMUTIL --version | cut -d ' ' -f 3
 }
-
-# TODO
-# Eigenlijk moet hier _geen_ /caching/-resolver worden gebruikt.
-# formaat: @HOSTNAME of leeg om de default servers te gebruiken
-# server="@dns1.uvt.nl"
-server="@ns0.tilburg1.surf.net"
 
 activate="no" # do not activate by default
 quiet="no"    # be verbose by default


### PR DESCRIPTION
We wanted timestamps on log messages for debugging. This might be useful in general. Also added some configuration to specify custom paths to external tools if needed (we need this). Moved all configuration (so also the server var) to the top, so its easier to patch a new version (by hand).
